### PR TITLE
ci: cache docker layers

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,23 +13,12 @@ jobs:
       - uses: actions/checkout@v4
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
-      - name: Cache Docker layers
-        uses: actions/cache@v3
-        with:
-          path: /tmp/.buildx-cache
-          key: ${{ runner.os }}-buildx-${{ github.sha }}
-          restore-keys: |
-            ${{ runner.os }}-buildx-
       - name: Build test image
         run: |
           docker buildx build --target builder \
-            --cache-from=type=local,src=/tmp/.buildx-cache \
-            --cache-to=type=local,dest=/tmp/.buildx-cache-new \
+            --cache-from=type=gha \
+            --cache-to=type=gha,mode=max \
             --load -t jfr-merger-ci .
-      - name: Move cache
-        run: |
-          rm -rf /tmp/.buildx-cache
-          mv /tmp/.buildx-cache-new /tmp/.buildx-cache
       - name: Run tests
         run: docker run --rm jfr-merger-ci /app/clojure/bin/clojure -M:test
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,8 +11,25 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+      - name: Cache Docker layers
+        uses: actions/cache@v3
+        with:
+          path: /tmp/.buildx-cache
+          key: ${{ runner.os }}-buildx-${{ github.sha }}
+          restore-keys: |
+            ${{ runner.os }}-buildx-
       - name: Build test image
-        run: docker build --target builder -t jfr-merger-ci .
+        run: |
+          docker build --target builder \
+            --cache-from=type=local,src=/tmp/.buildx-cache \
+            --cache-to=type=local,dest=/tmp/.buildx-cache-new \
+            -t jfr-merger-ci .
+      - name: Move cache
+        run: |
+          rm -rf /tmp/.buildx-cache
+          mv /tmp/.buildx-cache-new /tmp/.buildx-cache
       - name: Run tests
         run: docker run --rm jfr-merger-ci /app/clojure/bin/clojure -M:test
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,10 +22,10 @@ jobs:
             ${{ runner.os }}-buildx-
       - name: Build test image
         run: |
-          docker build --target builder \
+          docker buildx build --target builder \
             --cache-from=type=local,src=/tmp/.buildx-cache \
             --cache-to=type=local,dest=/tmp/.buildx-cache-new \
-            -t jfr-merger-ci .
+            --load -t jfr-merger-ci .
       - name: Move cache
         run: |
           rm -rf /tmp/.buildx-cache

--- a/README.md
+++ b/README.md
@@ -37,16 +37,17 @@ should show many steps marked as cached and finish much faster.
 ```bash
 docker buildx build --target builder \
   --cache-from=type=local,src=/tmp/.buildx-cache \
-  --cache-to=type=local,dest=/tmp/.buildx-cache-new \
+  --cache-to=type=local,dest=/tmp/.buildx-cache-new,mode=max \
   --load -t jfr-merger-ci .
 
 mv /tmp/.buildx-cache-new /tmp/.buildx-cache
 
 docker buildx build --target builder \
   --cache-from=type=local,src=/tmp/.buildx-cache \
-  --cache-to=type=local,dest=/tmp/.buildx-cache-new \
+  --cache-to=type=local,dest=/tmp/.buildx-cache-new,mode=max \
   --load -t jfr-merger-ci .
 ```
 
 If the cache is used, the output of the second command will contain
-`CACHED` for most layers.
+`CACHED` for most layers. The `mode=max` option ensures that all
+intermediate layers, including base images, are saved to the cache.

--- a/README.md
+++ b/README.md
@@ -28,3 +28,25 @@ You can upload multiple JFR files—they will be merged and converted into a
 or just
 
 >docker compose up
+
+## Checking the Docker build cache
+
+To make sure layer caching works, run the build twice. The second run
+should show many steps marked as cached and finish much faster.
+
+```bash
+docker buildx build --target builder \
+  --cache-from=type=local,src=/tmp/.buildx-cache \
+  --cache-to=type=local,dest=/tmp/.buildx-cache-new \
+  --load -t jfr-merger-ci .
+
+mv /tmp/.buildx-cache-new /tmp/.buildx-cache
+
+docker buildx build --target builder \
+  --cache-from=type=local,src=/tmp/.buildx-cache \
+  --cache-to=type=local,dest=/tmp/.buildx-cache-new \
+  --load -t jfr-merger-ci .
+```
+
+If the cache is used, the output of the second command will contain
+`CACHED` for most layers.


### PR DESCRIPTION
## Summary
- cache Docker build layers in CI to speed up builds

## Testing
- `docker build --target builder -t jfr-merger-ci .` *(fails: command not found)*
- `clojure -M:test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c3d8fa590483278aec0f56add2c19b