### PR TITLE
Improve CI caching for Docker and Clojure deps

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,9 +11,48 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Cache Docker layers
+        uses: actions/cache@v4
+        with:
+          path: /tmp/.buildx-cache
+          key: ${{ runner.os }}-buildx-${{ github.sha }}
+          restore-keys: |
+            ${{ runner.os }}-buildx-
+
+      - name: Cache Clojure dependencies
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/.m2
+            ~/.gitlibs
+          key: ${{ runner.os }}-clojure-${{ hashFiles('deps.edn') }}
+          restore-keys: |
+            ${{ runner.os }}-clojure-
+
       - name: Build test image
-        run: docker build --target builder -t jfr-merger-ci .
+        uses: docker/build-push-action@v5
+        with:
+          context: .
+          target: builder
+          load: true
+          tags: jfr-merger-ci:latest
+          cache-from: type=local,src=/tmp/.buildx-cache
+          cache-to: type=local,dest=/tmp/.buildx-cache-new,mode=max
+
+      - name: Move Docker layer cache
+        run: |
+          rm -rf /tmp/.buildx-cache
+          mv /tmp/.buildx-cache-new /tmp/.buildx-cache
+
       - name: Run tests
-        run: docker run --rm jfr-merger-ci /app/clojure/bin/clojure -M:test
+        run: |
+          mkdir -p ~/.m2 ~/.gitlibs
+          docker run --rm \
+            -v $HOME/.m2:/root/.m2 \
+            -v $HOME/.gitlibs:/root/.gitlibs \
+            jfr-merger-ci:latest /app/clojure/bin/clojure -M:test
 
 


### PR DESCRIPTION
## Summary
- set up Docker Buildx with a shared cache to reuse image layers between runs
- cache local Maven and gitlib directories and mount them into the test container to avoid re-downloading Clojure deps

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68dcc0f5a00c8327b03727b36063c85b